### PR TITLE
Simplify

### DIFF
--- a/src/TypeClasses/FlipTypes.jl
+++ b/src/TypeClasses/FlipTypes.jl
@@ -1,4 +1,4 @@
-using TypeClasses.Utils
+using .TypeClasses.Utils
 
 """
     flip_types(value::T{S{A}})::S{T{A}}

--- a/src/TypeInstances/AbstractVector.jl
+++ b/src/TypeInstances/AbstractVector.jl
@@ -1,6 +1,4 @@
 
-using TypeClasses
-
 """
 considerations: because `Base.typename(Vector).wrapper == Array`, we dispatch everything on AbstractArray to support AbstractVector.
 

--- a/src/TypeInstances/Callable.jl
+++ b/src/TypeInstances/Callable.jl
@@ -1,6 +1,3 @@
-using TypeClasses
-
-
 # Monoid instances
 # ================
 

--- a/src/TypeInstances/Dict.jl
+++ b/src/TypeInstances/Dict.jl
@@ -1,5 +1,3 @@
-using TypeClasses
-
 """
 IMPORTANT: we do NOT support AbstractDict, because there is no general way to map over such a type,
 i.e. we cannot easily construct new AbstractDict from the same type, but with small alterations.

--- a/src/TypeInstances/Iterable.jl
+++ b/src/TypeInstances/Iterable.jl
@@ -1,5 +1,3 @@
-using TypeClasses
-
 """
 Iterables can be seen two ways. On the one hand, an iterable is mainly defined by its `iterate` method, which can be
 thought of as a kind of TypeClass (similar to how `map`, `combine`, `Monad`, or `Monoid` refer to TypeClasses). In

--- a/src/TypeInstances/Pair.jl
+++ b/src/TypeInstances/Pair.jl
@@ -1,5 +1,3 @@
-using TypeClasses
-
 # we assume that Pair(a::A, b::B) always constructs the most specific Pair type Pair{A, B}
 # TODO is this really the case? It could be, but is it true?
 

--- a/src/TypeInstances/State.jl
+++ b/src/TypeInstances/State.jl
@@ -1,5 +1,3 @@
-using TypeClasses
-
 # Monoid instances
 # ================
 

--- a/src/TypeInstances/String.jl
+++ b/src/TypeInstances/String.jl
@@ -1,5 +1,3 @@
-using TypeClasses
-
 # Monoid
 # ======
 

--- a/src/TypeInstances/Tuple.jl
+++ b/src/TypeInstances/Tuple.jl
@@ -1,6 +1,3 @@
-using TypeClasses
-
-
 # MonoidAlternative
 # =================
 

--- a/src/TypeInstances/Writer.jl
+++ b/src/TypeInstances/Writer.jl
@@ -1,5 +1,3 @@
-using TypeClasses
-
 # MonoidAlternative
 # =================
 

--- a/src/TypeInstances_DataTypesBasic/Either.jl
+++ b/src/TypeInstances_DataTypesBasic/Either.jl
@@ -19,14 +19,11 @@ TypeClasses.orelse(a::Const, b::Identity) = b
 
 # for generic Either, both Const and Identity can be combined on their own, but combining Const with Identity gives Identity.
 # Hence, to comply with monoid laws, the neutral element is `Cons(neutral(L))`
-TypeClasses.neutral(::Type{Either{L, R}}) where {L, R} = Const(neutral(L))
-TypeClasses.neutral(::Type{Either{L, <:UR}}) where {L, UR} = Const(neutral(L))
+TypeClasses.neutral(::Type{E}) where {L, E<:Either{L}} = Const(neutral(L))
 # we don't provide the fallback of Option if given a generic Either type, as the monoid laws would get broken
 # TypeClasses.neutral(::Type{Either}) = Const(nothing)
 
-TypeClasses.neutral(::Type{Option{T}}) where T = Const(nothing)
-TypeClasses.neutral(::Type{Option{<:UT}}) where UT = Const(nothing)
-TypeClasses.neutral(::Type{Option}) = Const(nothing)
+TypeClasses.neutral(::Type{<:Option})= Const(nothing)
 
 
 
@@ -37,10 +34,7 @@ TypeClasses.ap(f::Const, x::Identity) = f
 TypeClasses.ap(f::Identity, x::Const) = x
 
 # you can think of Identity as the neutral element for monadic composition: adding Identity as an additional layer, and then flattening the layers, nothing is changed in total.
-TypeClasses.pure(::Type{Either{L, R}}, a) where {L, R} = Identity(a)  # includes Option, as Const{Nothing} => L=Nothing
-TypeClasses.pure(::Type{Either{L, <:UR}}, a) where {L, UR} = Identity(a)
-TypeClasses.pure(::Type{Either{<:UL, R}}, a) where {UL, R} = Identity(a)  # includes Try as Const{<:Exception} => UL = Exception
-TypeClasses.pure(::Type{Either{<:UL, <:UR}}, a) where {UL, UR} = Identity(a)  # includes Either
+TypeClasses.pure(::Type{<:Either}, a) = Identity(a)  # includes Option, as Const{Nothing} => L=Nothing
 
 # we cannot overload this generically, because `Base.map(f, ::Vector...)` would get overwritten as well (even without warning surprisingly)
 # hence we do it individually for Either


### PR DESCRIPTION
This PR makes some simplifications:
1. It removes the `using TypeClasses` that appears in many files that are `include`d _within_ the `TypeClasses` module
2. It simplifies the `pure` and `neutral` functions in `Either.jl`